### PR TITLE
fixing Dockerfile to go around error 'ADD failed: stat /var/lib/docke…

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,10 +1,10 @@
-FROM adaptris/interlok:latest-alpine
+FROM adaptris/interlok-base:snapshot-zulu
 
 EXPOSE 8080
 EXPOSE 5555
 
 RUN rm -f /opt/interlok/lib/adp-*.jar
 
-ADD ./build/docker/lib /opt/interlok/lib
-ADD ./build/docker/webapps /opt/interlok/webapps
-ADD ./build/docker/config /opt/interlok/config
+COPY lib /opt/interlok/lib
+COPY webapps /opt/interlok/webapps
+COPY config /opt/interlok/config

--- a/Dockerfile
+++ b/Dockerfile
@@ -5,6 +5,6 @@ EXPOSE 5555
 
 RUN rm -f /opt/interlok/lib/adp-*.jar
 
-ADD lib /opt/interlok/lib
-ADD webapps /opt/interlok/webapps
-ADD config /opt/interlok/config
+ADD ./build/docker/lib /opt/interlok/lib
+ADD ./build/docker/webapps /opt/interlok/webapps
+ADD ./build/docker/config /opt/interlok/config


### PR DESCRIPTION
…r/tmp/docker-builder798244407/lib: no such file or directory'"