### PR TITLE
Fix for users with capital letters in their usernames

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -5,7 +5,7 @@ plugins {
 ext {
   interlokParentGradle = 'https://raw.githubusercontent.com/adaptris/interlok-build-parent/main/v4/build.gradle'
   includeWar = 'true'
-  dockerPrefix = System.properties.getProperty('user.name')
+  dockerPrefix = System.properties.getProperty('user.name').toLowerCase()
 }
 
 allprojects {


### PR DESCRIPTION
## Motivation

.\gradlew docker failed if username contains an uppercase character; e.g.: Surnameinitial

## Modification

build.gradle: dockerPrefix now forces usename into lowercase with System.properties.getProperty('user.name').toLowerCase()

## Result

Users with capital letters in their username should no longer have issues running .\gradlew docker

## Testing

Check that the change is necessary by changing ".toLowerCase()" to ".toUpperCase()" and noting the failure. Users with already lowercase usernames should notice no difference
